### PR TITLE
Fix build failure of GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,4 +20,4 @@ jobs:
     - name: Checkout 🛎️
       uses: actions/checkout@v4
     - name: Build and Deploy 🚀
-      uses: onejar99/gitbook-build-publish-action@v1.0.3
+      uses: LawrenceHwang/gitbook-build-publish-action@bugfix


### PR DESCRIPTION
Uses the temporary bug fix github action from https://github.com/LawrenceHwang/gitbook-build-publish-action/tree/bug-gitbook-plugin-github-issue-feedback.

The fix is confirmed in the [GitHub Action run](https://github.com/LawrenceHwang/cpumemory-zhtw/actions/runs/9707754852/job/26793478122).